### PR TITLE
[!HOTFIX] 일기카드 수정시 질문 데이터 삭제되는 문제 해결

### DIFF
--- a/src/main/java/com/example/toyou/app/dto/CardRequest.java
+++ b/src/main/java/com/example/toyou/app/dto/CardRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class CardRequest {
 
     @Getter
+    @Builder
     public static class createCardDTO {
 
         @Schema(description = "공개 여부", nullable = false, example = "true")

--- a/src/main/java/com/example/toyou/app/dto/CardRequest.java
+++ b/src/main/java/com/example/toyou/app/dto/CardRequest.java
@@ -2,6 +2,7 @@ package com.example.toyou.app.dto;
 
 import com.example.toyou.domain.enums.QuestionType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public class CardRequest {
     }
 
     @Getter
+    @Builder
     public static class updateCardDTO {
         @Schema(description = "공개 여부", nullable = false, example = "true")
         private boolean exposure;
@@ -24,6 +26,7 @@ public class CardRequest {
     }
 
     @Getter
+    @Builder
     public static class qa {
 
         @Schema(description = "질문 식별자", nullable = false, example = "1")

--- a/src/main/java/com/example/toyou/domain/DiaryCard.java
+++ b/src/main/java/com/example/toyou/domain/DiaryCard.java
@@ -22,7 +22,7 @@ public class DiaryCard extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "diaryCard", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "diaryCard")
     @Builder.Default
     private List<Question> questionList = new ArrayList<>();
 

--- a/src/main/java/com/example/toyou/service/CardService.java
+++ b/src/main/java/com/example/toyou/service/CardService.java
@@ -116,8 +116,10 @@ public class CardService {
         if(user != card.getUser()) throw new GeneralException(ErrorStatus.NOT_OWNER);
 
         List<Question> questionList = card.getQuestionList();
-        questionList.forEach(question -> question.setDiaryCard(null)); // 질문 목록의 각 질문에 대해 카드 ID를 null로 설정
-        questionList.clear(); // 카드의 질문 목록 비우기
+        questionList.forEach(question -> {
+            question.setDiaryCard(null);
+            questionRepository.save(question); // 기존 질문들을 저장
+        });
 
         // 1.qaList에서 각 qa 객체의 questionId를 사용하여 Question을 검색
         // 2.answer를 수정 & 일기카드 연동

--- a/src/main/java/com/example/toyou/service/CardService.java
+++ b/src/main/java/com/example/toyou/service/CardService.java
@@ -60,6 +60,8 @@ public class CardService {
         DiaryCard newCard = CardConverter.toCard(user, request.isExposure());
         cardRepository.save(newCard);
 
+        List<Question> questionList = newCard.getQuestionList();
+
         // 1.qaList에서 각 qa 객체의 questionId를 사용하여 Question을 검색
         // 2.answer를 수정 & 일기카드 연동
         request.getQuestionList()
@@ -78,6 +80,8 @@ public class CardService {
 
                     question.setAnswer(safeContent);
                     question.setDiaryCard(newCard);
+
+                    questionList.add(question);
                 });
 
         return CardConverter.toCreateCardDTO(newCard.getId());
@@ -116,10 +120,8 @@ public class CardService {
         if(user != card.getUser()) throw new GeneralException(ErrorStatus.NOT_OWNER);
 
         List<Question> questionList = card.getQuestionList();
-        questionList.forEach(question -> {
-            question.setDiaryCard(null);
-            questionRepository.save(question); // 기존 질문들을 저장
-        });
+        questionList.forEach(question -> question.setDiaryCard(null));
+        questionList.clear();
 
         // 1.qaList에서 각 qa 객체의 questionId를 사용하여 Question을 검색
         // 2.answer를 수정 & 일기카드 연동
@@ -139,6 +141,8 @@ public class CardService {
 
                     question.setAnswer(safeContent);
                     question.setDiaryCard(card);
+
+                    questionList.add(question);
                 });
 
         card.setExposure(request.isExposure()); // 공개 여부 설정

--- a/src/test/java/com/example/toyou/service/CardServiceTest.java
+++ b/src/test/java/com/example/toyou/service/CardServiceTest.java
@@ -1,15 +1,27 @@
 package com.example.toyou.service;
 
+import com.example.toyou.app.dto.CardRequest;
 import com.example.toyou.domain.DiaryCard;
+import com.example.toyou.domain.Question;
 import com.example.toyou.domain.User;
+import com.example.toyou.domain.enums.Emotion;
+import com.example.toyou.domain.enums.QuestionType;
 import com.example.toyou.repository.CardRepository;
+import com.example.toyou.repository.QuestionRepository;
 import com.example.toyou.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,6 +33,9 @@ class CardServiceTest {
     @Autowired private CardRepository cardRepository;
     @Autowired private CardService cardService;
     @Autowired private UserRepository userRepository;
+    @Autowired private QuestionRepository questionRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(CardServiceTest.class);
 
     @Test
     @DisplayName("일기카드 공개여부를 전환합니다.")
@@ -43,5 +58,87 @@ class CardServiceTest {
 
         // then
         assertTrue(card.isExposure(), "일기카드 공개여부 전환에 실패했습니다.");
+    }
+
+    @Test
+    @DisplayName("일기카드 수정 성공")
+    void updateCardTest() {
+        Logger logger = LoggerFactory.getLogger(getClass());
+
+        // given
+        User user = User.builder().nickname("test").build();
+        userRepository.save(user);
+
+        Question question1 = Question.builder()
+                .user(user)
+                .questioner("questioner1")
+                .content("content1")
+                .answer("answer1")
+                .questionType(QuestionType.SHORT_ANSWER)
+                .build();
+        questionRepository.save(question1);
+
+        Question question2 = Question.builder()
+                .user(user)
+                .questioner("questioner2")
+                .content("content2")
+                .answer("answer2")
+                .questionType(QuestionType.SHORT_ANSWER)
+                .build();
+        questionRepository.save(question2);
+
+        Question question3 = Question.builder()
+                .user(user)
+                .questioner("questioner3")
+                .content("content3")
+                .answer("answer3")
+                .questionType(QuestionType.SHORT_ANSWER)
+                .build();
+        questionRepository.save(question3);
+
+        CardRequest.updateCardDTO updateDto = CardRequest.updateCardDTO.builder()
+                .exposure(true)
+                .questionList(new ArrayList<>(List.of(
+                        CardRequest.qa.builder()
+                                .questionId(question2.getId())
+                                .answer("answer2.1")
+                                .build(),
+                        CardRequest.qa.builder()
+                                .questionId(question3.getId())
+                                .answer("answer3")
+                                .build()
+                )))
+                .build();
+
+        List<Question> questionList = Arrays.asList(question1, question2);
+
+        DiaryCard card = DiaryCard.builder()
+                .exposure(false)
+                .user(user)
+                .emotion(Emotion.NORMAL)
+                .questionList(questionList)
+                .build();
+
+        cardRepository.save(card);
+
+        logger.info("수정 전, questionList: {}", card.getQuestionList().stream()
+                .map(Question::getId)
+                .collect(Collectors.toList()));
+
+        // when
+        cardService.updateCard(user.getId(), card.getId(), updateDto);
+
+        // then
+        DiaryCard updatedCard = cardRepository.findById(card.getId()).orElseThrow(
+                () -> new AssertionError("Updated card not found")
+        );
+
+        logger.info("수정 후, questionList: {}", updatedCard.getQuestionList().stream()
+                .map(Question::getId)
+                .collect(Collectors.toList()));
+
+        assertEquals(question2.getId(), updatedCard.getQuestionList().get(0).getId(), "question2가 첫 번째 인덱스에 없습니다.");
+        assertEquals("answer2.1", updatedCard.getQuestionList().get(0).getAnswer(), "question2의 답변이 변경되지 않았습니다.");
+        assertEquals(question3.getId(), updatedCard.getQuestionList().get(1).getId(), "질문 목록에 question3이 없습니다.");
     }
 }

--- a/src/test/java/com/example/toyou/service/CardServiceTest.java
+++ b/src/test/java/com/example/toyou/service/CardServiceTest.java
@@ -204,4 +204,49 @@ class CardServiceTest {
         assertEquals("answer2.1", updatedCard.getQuestionList().get(0).getAnswer(), "question2의 답변이 변경되지 않았습니다.");
         assertEquals(question3.getId(), updatedCard.getQuestionList().get(1).getId(), "질문 목록에 question3이 없습니다.");
     }
+
+    @Test
+    @DisplayName("일기카드 삭제 성공")
+    void deleteCardTest() {
+        // given
+        User user = User.builder().nickname("test").build();
+        userRepository.save(user);
+
+        Question question1 = Question.builder()
+                .user(user)
+                .questioner("questioner1")
+                .content("content1")
+                .answer("answer1")
+                .questionType(QuestionType.SHORT_ANSWER)
+                .build();
+        questionRepository.save(question1);
+
+        Question question2 = Question.builder()
+                .user(user)
+                .questioner("questioner2")
+                .content("content2")
+                .answer("answer2")
+                .questionType(QuestionType.SHORT_ANSWER)
+                .build();
+        questionRepository.save(question2);
+
+        List<Question> questionList = Arrays.asList(question1, question2);
+
+        DiaryCard card = DiaryCard.builder()
+                .exposure(false)
+                .user(user)
+                .emotion(Emotion.NORMAL)
+                .questionList(new ArrayList<>(questionList))
+                .build();
+
+        cardRepository.save(card);
+
+        // when
+        cardService.deleteCard(user.getId(), card.getId());
+
+        // then
+        assertFalse(cardRepository.existsById(card.getId()), "DiaryCard should be deleted.");
+        assertTrue(questionRepository.existsById(question1.getId()), "Question1 should remain in the database.");
+        assertTrue(questionRepository.existsById(question2.getId()), "Question2 should remain in the database.");
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #13 

## 💻 작업 내용
- [x] 일기카드 수정 테스트 작성
- [x] Card - Question 1:N 관계 설정 중 Cascade.ALL 제거
- [x] 일기카드 삭제 테스트 작성

## ✅ PR Point
1. Cascade로 설정한 부모-자식 관계 해제. 일대다 관계일 뿐, 부모-자식 X
<img width="364" alt="스크린샷 2024-11-12 오후 12 38 04" src="https://github.com/user-attachments/assets/9f4f059e-92c7-4068-835a-b6bb5819362a">  

- Cascade 및 연관관계 관련 학습 필요  
- 나중에 Cascade 추가해서 테스트했을 때 성공함(왜 또 되지..)
