### PR TITLE
[FRIEND] 친구 요청/삭제 API 리팩토링

### DIFF
--- a/src/main/java/com/example/toyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/toyou/apiPayload/code/status/ErrorStatus.java
@@ -43,6 +43,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 알림 에러
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM400", "해당하는 알림이 존재하지 않습니다."),
     ALARM_NOT_MINE(HttpStatus.FORBIDDEN, "ALARM401", "해당 유저의 알림이 아닙니다."),
+    FRIEND_REQUEST_ALARM_CANT_BE_DELETED(HttpStatus.FORBIDDEN, "ALARM402", "친구 요청 알림은 직접 삭제할 수 없습니다."),
 
     // Oauth 에러
     OAUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "OAUTH400", "유효하지 않은 OAUTH 토큰입니다."),

--- a/src/main/java/com/example/toyou/service/AlarmService.java
+++ b/src/main/java/com/example/toyou/service/AlarmService.java
@@ -6,6 +6,7 @@ import com.example.toyou.app.dto.AlarmResponse;
 import com.example.toyou.converter.AlarmConverter;
 import com.example.toyou.domain.Alarm;
 import com.example.toyou.domain.User;
+import com.example.toyou.domain.enums.AlarmType;
 import com.example.toyou.repository.AlarmRepository;
 import com.example.toyou.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +59,9 @@ public class AlarmService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ALARM_NOT_FOUND));
 
         if(alarm.getUser() != user) throw new GeneralException(ErrorStatus.ALARM_NOT_MINE);
+
+        if(alarm.getAlarmType() == AlarmType.FRIEND_REQUEST)
+            throw new GeneralException(ErrorStatus.FRIEND_REQUEST_ALARM_CANT_BE_DELETED);
 
         alarmRepository.delete(alarm);
     }

--- a/src/main/java/com/example/toyou/service/FriendService.java
+++ b/src/main/java/com/example/toyou/service/FriendService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -167,10 +168,9 @@ public class FriendService {
                 );
 
         // 알람 삭제
-        Alarm alarmToDelete = alarmRepository.findByFriendRequest(friendRequestToDelete)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.ALARM_NOT_FOUND));
+        Optional<Alarm> alarmToDelete = alarmRepository.findByFriendRequest(friendRequestToDelete);
 
-        if (alarmToDelete != null) alarmRepository.delete(alarmToDelete);
+        alarmToDelete.ifPresent(alarmRepository::delete);
 
         friendRepository.delete(friendRequestToDelete);
     }


### PR DESCRIPTION
## 🔥 Related Issues
- close #19 

## 💻 작업 내용
- [x] 친구 요청 알림에 알림 삭제 API를 사용할 수 없도록 예외처리 코드 추가
- [x] 친구 삭제시 함께 삭제되는 알림을 Optional로 변경