### PR TITLE
[API] 요청/응답 내 유저 이름을 ID(PK)로 대체

### DIFF
--- a/src/main/java/com/example/toyou/app/controller/FcmController.java
+++ b/src/main/java/com/example/toyou/app/controller/FcmController.java
@@ -48,10 +48,10 @@ public class FcmController {
     }
 
     @GetMapping("/token")
-    @Operation(summary = "FCM 토큰 조회", description = "닉네임을 통해 해당 사용자의 FCM 토큰을 조회합니다.")
-    public CustomApiResponse<FcmResponse.getTokenDto> getToken(@RequestParam String keyword) {
+    @Operation(summary = "FCM 토큰 조회", description = "유저 식별자를 통해 해당 사용자의 FCM 토큰을 조회합니다.")
+    public CustomApiResponse<FcmResponse.getTokenDto> getToken(@RequestParam Long userId) {
 
-        FcmResponse.getTokenDto token = fcmService.getToken(keyword);
+        FcmResponse.getTokenDto token = fcmService.getToken(userId);
 
         return CustomApiResponse.onSuccess(token);
     }

--- a/src/main/java/com/example/toyou/app/controller/FriendController.java
+++ b/src/main/java/com/example/toyou/app/controller/FriendController.java
@@ -67,9 +67,9 @@ public class FriendController {
 
         Long userId = Long.parseLong(principal.getName());
 
-        FcmResponse.getMyNameDto myName = friendService.createFriendRequest(userId, request);
+        FcmResponse.getMyNameDto response = friendService.createFriendRequest(userId, request);
 
-        return CustomApiResponse.onSuccess(myName);
+        return CustomApiResponse.onSuccess(response);
     }
 
     @DeleteMapping
@@ -91,9 +91,9 @@ public class FriendController {
 
         Long userId = Long.parseLong(principal.getName());
 
-        FcmResponse.getMyNameDto myName = friendService.acceptFriendRequest(userId, request);
+        FcmResponse.getMyNameDto response = friendService.acceptFriendRequest(userId, request);
 
-        return CustomApiResponse.onSuccess(myName);
+        return CustomApiResponse.onSuccess(response);
     }
 
     @GetMapping("/yesterday")

--- a/src/main/java/com/example/toyou/app/dto/FriendRequestRequest.java
+++ b/src/main/java/com/example/toyou/app/dto/FriendRequestRequest.java
@@ -2,27 +2,28 @@ package com.example.toyou.app.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 public class FriendRequestRequest {
 
     @Getter
     public static class createFriendRequestDTO{
-        @NotEmpty
+        @NotNull
         @Schema(description = "유저 ID", nullable = false, example = "1")
         private Long userId;
     }
 
     @Getter
     public static class deleteFriendRequestDTO{
-        @NotEmpty
+        @NotNull
         @Schema(description = "유저 ID", nullable = false, example = "1")
         private Long userId;
     }
 
     @Getter
     public static class acceptFriendRequestDTO{
-        @NotEmpty
+        @NotNull
         @Schema(description = "유저 ID", nullable = false, example = "1")
         private Long userId;
     }

--- a/src/main/java/com/example/toyou/app/dto/FriendRequestRequest.java
+++ b/src/main/java/com/example/toyou/app/dto/FriendRequestRequest.java
@@ -9,21 +9,21 @@ public class FriendRequestRequest {
     @Getter
     public static class createFriendRequestDTO{
         @NotEmpty
-        @Schema(description = "닉네임", nullable = false, example = "철수")
-        private String nickname;
+        @Schema(description = "유저 ID", nullable = false, example = "1")
+        private Long userId;
     }
 
     @Getter
     public static class deleteFriendRequestDTO{
         @NotEmpty
-        @Schema(description = "닉네임", nullable = false, example = "철수")
-        private String nickname;
+        @Schema(description = "유저 ID", nullable = false, example = "1")
+        private Long userId;
     }
 
     @Getter
     public static class acceptFriendRequestDTO{
         @NotEmpty
-        @Schema(description = "닉네임", nullable = false, example = "철수")
-        private String nickname;
+        @Schema(description = "유저 ID", nullable = false, example = "1")
+        private Long userId;
     }
 }

--- a/src/main/java/com/example/toyou/app/dto/FriendResponse.java
+++ b/src/main/java/com/example/toyou/app/dto/FriendResponse.java
@@ -25,7 +25,8 @@ public class FriendResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class friendInfo {
-
+        @Schema(description = "유저 ID", nullable = false, example = "1")
+        private Long userId;
         @Schema(description = "닉네임", nullable = false, example = "철수")
         private String nickname;
         @Schema(description = "감정", nullable = false, example = "HAPPY")
@@ -39,7 +40,8 @@ public class FriendResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class searchFriendDTO {
-
+        @Schema(description = "유저 ID", nullable = false, example = "1")
+        private Long userId;
         @Schema(description = "닉네임", nullable = false, example = "철수")
         private String nickname;
         @Schema(description = "친구 관계 유형", nullable = false, example = "REQUEST_SENT")

--- a/src/main/java/com/example/toyou/app/dto/QuestionRequest.java
+++ b/src/main/java/com/example/toyou/app/dto/QuestionRequest.java
@@ -13,8 +13,8 @@ public class QuestionRequest {
     @Getter
     @Builder
     public static class createQuestionDTO{
-        @Schema(description = "질문 대상", nullable = false, example = "훈이")
-        private String target;
+        @Schema(description = "유저(질문 대상) ID", nullable = false, example = "1")
+        private Long targetId;
 
         @Schema(description = "질문 내용", nullable = false, example = "어제 뭐했어?")
         private String content;

--- a/src/main/java/com/example/toyou/converter/FriendConverter.java
+++ b/src/main/java/com/example/toyou/converter/FriendConverter.java
@@ -41,6 +41,7 @@ public class FriendConverter {
                     String ment = (todayEmotion != null) ? getMessageForEmotion(todayEmotion) : null;
 
                     return FriendResponse.friendInfo.builder()
+                            .userId(friend.getId())
                             .nickname(friend.getNickname())
                             .emotion(todayEmotion)
                             .ment(ment)
@@ -53,6 +54,7 @@ public class FriendConverter {
 
     public static FriendResponse.searchFriendDTO toSearchFriendDTO(User friend, FriendStatus friendStatus) {
         return FriendResponse.searchFriendDTO.builder()
+                .userId(friend.getId())
                 .nickname(friend.getNickname())
                 .friendStatus(friendStatus)
                 .build();

--- a/src/main/java/com/example/toyou/converter/QuestionConverter.java
+++ b/src/main/java/com/example/toyou/converter/QuestionConverter.java
@@ -60,7 +60,7 @@ public class QuestionConverter {
 
     public static QuestionRequest.createQuestionDTO toCreateQuestionDTO(User user, CustomQuestion cq) {
         return QuestionRequest.createQuestionDTO.builder()
-                .target(user.getNickname())
+                .targetId(user.getId())
                 .content(cq.getContent())
                 .questionType(cq.getQuestionType())
                 .anonymous(false)

--- a/src/main/java/com/example/toyou/service/FcmService.java
+++ b/src/main/java/com/example/toyou/service/FcmService.java
@@ -93,10 +93,10 @@ public class FcmService {
     /**
      * FCM Token 조회
      */
-    public FcmResponse.getTokenDto getToken(String nickname) {
-        log.info("[FCM Token 조회] keyword={}", nickname);
+    public FcmResponse.getTokenDto getToken(Long userId) {
+        log.info("[FCM Token 조회] userId={}", userId);
 
-        User user = userRepository.findByNickname(nickname)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUser(user);

--- a/src/main/java/com/example/toyou/service/FriendService.java
+++ b/src/main/java/com/example/toyou/service/FriendService.java
@@ -144,14 +144,14 @@ public class FriendService {
     @Transactional
     public FcmResponse.getMyNameDto createFriendRequest(Long userId, FriendRequestRequest.createFriendRequestDTO request) {
 
-        log.info("[친구 요청] userId={}, friendName={}", userId, request.getNickname());
+        log.info("[친구 요청] userId={}, friendId={}", userId, request.getUserId());
 
         // 본인 검색
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 친구 검색
-        User friend = userRepository.findByNickname(request.getNickname())
+        User friend = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 본인 스스로에게 친구 요청 불가능
@@ -178,14 +178,14 @@ public class FriendService {
     @Transactional
     public void deleteFriendRequest(Long userId, FriendRequestRequest.deleteFriendRequestDTO request) {
 
-        log.info("[친구 삭제 & 친구 요청 취소] userId={}, friendName={}", userId, request.getNickname());
+        log.info("[친구 삭제 & 친구 요청 취소] userId={}, friendId={}", userId, request.getUserId());
 
         // 유저 검색
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 친구 검색
-        User friend = userRepository.findByNickname(request.getNickname())
+        User friend = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 친구 요청 정보 확인
@@ -204,14 +204,14 @@ public class FriendService {
     @Transactional
     public FcmResponse.getMyNameDto acceptFriendRequest(Long userId, FriendRequestRequest.acceptFriendRequestDTO request) {
 
-        log.info("[친구 요청 승인] userId={}, friendName={}", userId, request.getNickname());
+        log.info("[친구 요청 승인] userId={}, friendId={}", userId, request.getUserId());
 
         // 친구 신청 수신자(승인한 본인)
         User receiver = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 친구 신청 발신자
-        User sender = userRepository.findByNickname(request.getNickname())
+        User sender = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 친구 요청 정보 확인

--- a/src/main/java/com/example/toyou/service/QuestionService.java
+++ b/src/main/java/com/example/toyou/service/QuestionService.java
@@ -47,7 +47,7 @@ public class QuestionService {
     @Transactional
     public FcmResponse.getMyNameDto createQuestion(Long userId, QuestionRequest.createQuestionDTO request) {
 
-        log.info("[질문 생성] userId={}, target={}", userId, request.getTarget());
+        log.info("[질문 생성] userId={}, targetId={}", userId, request.getTargetId());
 
         // 본인 검색
         User user = userRepository.findById(userId)
@@ -56,7 +56,7 @@ public class QuestionService {
         String questioner = user.getNickname();
 
         // 질문 대상 검색
-        User target = userRepository.findByNickname(request.getTarget())
+        User target = userRepository.findById(request.getTargetId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         if (user == target) throw new GeneralException(ErrorStatus.CANNOT_REQUEST_MYSELF);
@@ -144,7 +144,7 @@ public class QuestionService {
     public void autoCreateQuestion(QuestionRequest.createQuestionDTO request) {
 
         // 질문 대상 검색
-        User target = userRepository.findByNickname(request.getTarget())
+        User target = userRepository.findById(request.getTargetId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         QuestionType questionType = request.getQuestionType();


### PR DESCRIPTION
## 🔥 Related Issues
- close #23 

## ✅ To-Do
- [x] 요청 및 응답 데이터에서 username을 userId로 변경
- [x] 관련 컨트롤러, 서비스, DTO 코드 수정
- [x] API 명세서 업데이트 및 별도 정리

## 👀 ETC
- 추후 PK 노출 방지(ex.UUID, 암호화)를 위한 추가적인 방안 고려 예정