### PR TITLE
[USER] 닉네임 중복 확인 - 회원/비회원 구분

### DIFF
--- a/src/main/java/com/example/toyou/app/controller/UserController.java
+++ b/src/main/java/com/example/toyou/app/controller/UserController.java
@@ -52,9 +52,10 @@ public class UserController {
 
     @GetMapping("/nickname/check")
     @Operation(summary = "닉네임 중복 확인", description = "닉네임 중복 여부를 체크합니다.")
-    public CustomApiResponse<UserResponse.checkUserNicknameDTO> checkUserNickname(@RequestParam String nickname){
+    public CustomApiResponse<UserResponse.checkUserNicknameDTO> checkUserNickname(@RequestParam String nickname,
+                                                                                  @RequestParam(required = false) Long userId){
 
-        UserResponse.checkUserNicknameDTO exists = userService.checkUserNickname(nickname);
+        UserResponse.checkUserNicknameDTO exists = userService.checkUserNickname(nickname, userId);
 
         return CustomApiResponse.onSuccess(exists);
     }

--- a/src/main/java/com/example/toyou/app/dto/UserResponse.java
+++ b/src/main/java/com/example/toyou/app/dto/UserResponse.java
@@ -25,6 +25,9 @@ public class UserResponse {
     @AllArgsConstructor
     public static class GetMyPageDTO {
 
+        @Schema(description = "유저 ID", nullable = false, example = "1")
+        private Long userId;
+
         @Schema(description = "닉네임", nullable = false, example = "짱구")
         private String nickname;
 

--- a/src/main/java/com/example/toyou/service/UserService.java
+++ b/src/main/java/com/example/toyou/service/UserService.java
@@ -151,6 +151,7 @@ public class UserService {
         log.info("친구 수: {}", friendNum);
 
         return UserResponse.GetMyPageDTO.builder()
+                .userId(userId)
                 .nickname(user.getNickname())
                 .friendNum(friendNum)
                 .status(user.getStatus())

--- a/src/main/java/com/example/toyou/service/UserService.java
+++ b/src/main/java/com/example/toyou/service/UserService.java
@@ -78,29 +78,17 @@ public class UserService {
     /**
      * 닉네임 중복 확인
      */
-    public UserResponse.checkUserNicknameDTO checkUserNickname(String nickname) {
-        log.info("[닉네임 중복 확인] nickname={}", nickname);
+    public UserResponse.checkUserNicknameDTO checkUserNickname(String nickname, Long userId) {
+        log.info("[닉네임 중복 확인] nickname={}, userId={}", nickname, userId);
 
-        return UserResponse.checkUserNicknameDTO.builder()
-                .exists(userRepository.existsByNickname(nickname))
-                .build();
-    }
+        boolean isExist = userRepository.existsByNickname(nickname);
 
-    /**
-     * 닉네임 중복 확인(회원용)
-     */
-    public UserResponse.checkUserNicknameDTO checkUserNickname2(Long userId, String nickname) {
-        log.info("[닉네임 중복 확인(회원용)] nickname={}, userId={}", nickname, userId);
-
-        boolean isExist = false;
-
+        // 유저일 경우, 사용자의 현재 닉네임하고 동일하면 false 반환(사용 가능)
         if (userId != null) {
             User user = findById(userId);
-            if(!user.getNickname().equals(nickname) && userRepository.existsByNickname(nickname)) {
-                isExist = true;
+            if(user.getNickname().equals(nickname)) {
+                isExist = false;
             }
-        } else {
-            isExist = userRepository.existsByNickname(nickname);
         }
 
         return UserResponse.checkUserNicknameDTO.builder()


### PR DESCRIPTION
## 🔥 Related Issues
- close #24 

## 💻 작업 내용
- [x] 마이페이지 조회 API : 응답 본문 내 userId 추가
- [x] 닉네임 중복 확인 API : 응답 쿼리스트링 내 userId 추가, 서비스 코드 수정
- [x] API 명세서 업데이트 및 별도 정리