### PR TITLE
[refactor] 친구 목록 조회 성능 개선

### DIFF
--- a/k6-scripts/get-test.js
+++ b/k6-scripts/get-test.js
@@ -3,7 +3,7 @@ import { check, sleep } from 'k6';
 
 export let options = {
     stages: [
-        { duration: '1m', target: 3000 }
+        { duration: '1m', target: 1000 }
     ],
 };
 
@@ -18,7 +18,7 @@ const params = {
 };
 
 export default function () {
-    const res = http.get(`${BASE_URL}/users/home`, params);
+    const res = http.get(`${BASE_URL}/friends`, params);
     check(res, {
         'home: status is 2xx': (r) => r.status >= 200 && r.status < 300,
         'home: response time < 300ms': (r) => r.timings.duration < 300,

--- a/k6-scripts/get-test.js
+++ b/k6-scripts/get-test.js
@@ -20,8 +20,8 @@ const params = {
 export default function () {
     const res = http.get(`${BASE_URL}/friends`, params);
     check(res, {
-        'home: status is 2xx': (r) => r.status >= 200 && r.status < 300,
-        'home: response time < 300ms': (r) => r.timings.duration < 300,
+        'status is 2xx': (r) => r.status >= 200 && r.status < 300,
+        'response time < 300ms': (r) => r.timings.duration < 300,
     });
     sleep(1);
 }

--- a/src/main/java/com/example/toyou/common/cache/RedisCacheHelper.java
+++ b/src/main/java/com/example/toyou/common/cache/RedisCacheHelper.java
@@ -45,4 +45,12 @@ public class RedisCacheHelper {
 
         return result;
     }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void deleteFriendCache(Long userId) {
+        delete("friends:" + userId);
+    }
 }

--- a/src/main/java/com/example/toyou/repository/FriendRepository.java
+++ b/src/main/java/com/example/toyou/repository/FriendRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<FriendRequest, Long> {
 
+    // receiver가 탈퇴되지 않았으며, 친구 요청이 수락된 경우에 대해 조회
     @Query("""
         SELECT fr FROM FriendRequest fr
         JOIN FETCH fr.receiver
@@ -20,6 +21,7 @@ public interface FriendRepository extends JpaRepository<FriendRequest, Long> {
     """)
     List<FriendRequest> findBySenderAndAcceptedTrue(@Param("sender") User sender);
 
+    // receiver가 탈퇴되지 않았으며, 수락된 친구 요청이 있는 경우에 대해 조회
     @Query("""
         SELECT fr FROM FriendRequest fr
         JOIN FETCH fr.sender

--- a/src/main/java/com/example/toyou/repository/FriendRepository.java
+++ b/src/main/java/com/example/toyou/repository/FriendRepository.java
@@ -11,14 +11,22 @@ import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<FriendRequest, Long> {
 
-    // receiver가 탈퇴되지 않았으며, 친구 요청이 수락된 경우에 대해 조회
-    @Query("SELECT fr FROM FriendRequest fr " +
-            "WHERE fr.sender = :sender AND fr.accepted = true AND fr.receiver.isDeleted = false")
+    @Query("""
+        SELECT fr FROM FriendRequest fr
+        JOIN FETCH fr.receiver
+        WHERE fr.sender = :sender
+          AND fr.accepted = true
+          AND fr.receiver.isDeleted = false
+    """)
     List<FriendRequest> findBySenderAndAcceptedTrue(@Param("sender") User sender);
 
-    // receiver가 탈퇴되지 않았으며, 수락된 친구 요청이 있는 경우에 대해 조회
-    @Query("SELECT fr FROM FriendRequest fr " +
-            "WHERE fr.receiver = :sender AND fr.accepted = true AND fr.sender.isDeleted = false")
+    @Query("""
+        SELECT fr FROM FriendRequest fr
+        JOIN FETCH fr.sender
+        WHERE fr.receiver = :sender
+          AND fr.accepted = true
+          AND fr.sender.isDeleted = false
+    """)
     List<FriendRequest> findByReceiverAndAcceptedTrue(@Param("sender") User sender);
 
     @Query("SELECT fr FROM FriendRequest fr " +


### PR DESCRIPTION
## 🔥 Related Issues
- close #39 

## 💻 작업 내용
- [x] 캐싱 적용
- [x] N+1 문제 → fetch join 적용
- [x] 부하 테스트 전후 비교

## ✅ PR Point
### 캐싱 적용
- 친구 목록 조회 시 캐시(`friends:userId`)에 저장
- 친구 추가/삭제 시 해당 캐시 명시적 삭제
- 회원 탈퇴 시: 캐시 미적용 (5분 TTL 내 캐시 데이터 허용)
<br>

### N+1 문제 → fetch join 적용
<details>
<summary> FriendRequest → User 참조가 lazy 로딩되어, 친구 수만큼 개별 조회 쿼리 발생 </summary>

```sql
2025-07-05T10:44:04.920+09:00  INFO 80017 --- [nio-8080-exec-3] c.example.toyou.service.FriendService    : [친구 목록 조회] userId=1
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        u1_0.id=? 
        and (
            u1_0.is_deleted = 0
        )
Hibernate: 
    select
        fr1_0.id,
        fr1_0.accepted,
        fr1_0.checked,
        fr1_0.created_at,
        fr1_0.receiver_id,
        fr1_0.sender_id,
        fr1_0.updated_at 
    from
        friend_request fr1_0 
    join
        users r1_0 
            on r1_0.id=fr1_0.receiver_id 
            and (r1_0.is_deleted = 0) 
    where
        fr1_0.sender_id=? 
        and fr1_0.accepted=1 
        and r1_0.is_deleted=0
Hibernate: 
    select
        fr1_0.id,
        fr1_0.accepted,
        fr1_0.checked,
        fr1_0.created_at,
        fr1_0.receiver_id,
        fr1_0.sender_id,
        fr1_0.updated_at 
    from
        friend_request fr1_0 
    join
        users s1_0 
            on s1_0.id=fr1_0.sender_id 
            and (s1_0.is_deleted = 0) 
    where
        fr1_0.receiver_id=? 
        and fr1_0.accepted=1 
        and s1_0.is_deleted=0
2025-07-05T10:44:05.021+09:00  INFO 80017 --- [nio-8080-exec-3] c.example.toyou.service.FriendService    : 조회된 친구 수 : 3
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        u1_0.id=? 
        and (
            u1_0.is_deleted = 0
        )
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        u1_0.id=? 
        and (
            u1_0.is_deleted = 0
        )
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        u1_0.id=? 
        and (
            u1_0.is_deleted = 0
        )
    
```
</details>
    
<details>
<summary> fetch join 적용으로 FriendRequest와 연관된 User를 한 번에 조회하도록 개선 </summary>

```sql
2025-07-05T10:45:17.159+09:00  INFO 81393 --- [nio-8080-exec-1] c.example.toyou.service.FriendService    : [친구 목록 조회] userId=1
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        u1_0.id=? 
        and (
            u1_0.is_deleted = 0
        )
Hibernate: 
    select
        fr1_0.id,
        fr1_0.accepted,
        fr1_0.checked,
        fr1_0.created_at,
        r1_0.id,
        r1_0.ad_consent,
        r1_0.created_at,
        r1_0.deleted_at,
        r1_0.is_deleted,
        r1_0.nickname,
        r1_0.oauth_access_token,
        r1_0.oauth_id,
        r1_0.provider,
        r1_0.status,
        r1_0.today_emotion,
        r1_0.updated_at,
        fr1_0.sender_id,
        fr1_0.updated_at 
    from
        friend_request fr1_0 
    join
        users r1_0 
            on r1_0.id=fr1_0.receiver_id 
            and (r1_0.is_deleted = 0) 
    where
        fr1_0.sender_id=? 
        and fr1_0.accepted=1 
        and r1_0.is_deleted=0
Hibernate: 
    select
        fr1_0.id,
        fr1_0.accepted,
        fr1_0.checked,
        fr1_0.created_at,
        fr1_0.receiver_id,
        s1_0.id,
        s1_0.ad_consent,
        s1_0.created_at,
        s1_0.deleted_at,
        s1_0.is_deleted,
        s1_0.nickname,
        s1_0.oauth_access_token,
        s1_0.oauth_id,
        s1_0.provider,
        s1_0.status,
        s1_0.today_emotion,
        s1_0.updated_at,
        fr1_0.updated_at 
    from
        friend_request fr1_0 
    join
        users s1_0 
            on s1_0.id=fr1_0.sender_id 
            and (s1_0.is_deleted = 0) 
    where
        fr1_0.receiver_id=? 
        and fr1_0.accepted=1 
        and s1_0.is_deleted=0
2025-07-05T10:45:17.422+09:00  INFO 81393 --- [nio-8080-exec-1] c.example.toyou.service.FriendService    : 조회된 친구 수 : 3
```
</details>
    
<details>
<summary>5분(설정한 TTL) 이내에 한 번 더 요청하면?</summary>    

```sql
-- Cache Hit : DB 조회 없이 캐시에서 응답됨
2025-07-05T10:52:18.937+09:00  INFO 81393 --- [nio-8080-exec-5] c.example.toyou.service.FriendService    : [친구 목록 조회] userId=1
```
</details>
<br>

### 단일 요청 시간 변화
- 시나리오 : 친구 1,000명
- 개선 전 : 280 ~ 300ms
- 개선 후
    - 첫 번째 조회 : 약 150ms(fetch join 적용, DB에서 조회)
    - 이후 조회(5분 이내) : 약 20ms(캐시에서 조회)
<br>

### K6 테스트
시나리오 : 1분 동안 VU(가상 사용자)가 1000명까지 점진적으로 증가(유저 별 친구 100명)

<details>
<summary>캐싱 전 (TPS : 164, 응답 시간 평균 2.0초)</summary>

```bash

         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: k6-scripts/get-test.js
 web dashboard: http://127.0.0.1:5665
        output: -

     scenarios: (100.00%) 1 scenario, 1000 max VUs, 1m30s max duration (incl. graceful stop):
              * default: Up to 1000 looping VUs for 1m0s over 1 stages (gracefulRampDown: 30s, gracefulStop: 30s)

  █ TOTAL RESULTS 

    checks_total.......................: 21632  327.206223/s
    checks_succeeded...................: 59.51% 12875 out of 21632
    checks_failed......................: 40.48% 8757 out of 21632

    ✓ home: status is 2xx
    ✗ home: response time < 300ms
      ↳  19% — ✓ 2059 / ✗ 8757

    HTTP
    http_req_duration.......................................................: avg=2.06s min=17.57ms med=1.97s max=6.44s p(90)=4.22s p(95)=4.87s
      { expected_response:true }............................................: avg=2.06s min=17.57ms med=1.97s max=6.44s p(90)=4.22s p(95)=4.87s
    http_req_failed.........................................................: 0.00%  0 out of 10816
    http_reqs...............................................................: 10816  163.603112/s

    EXECUTION
    iteration_duration......................................................: avg=3.06s min=1.01s   med=2.97s max=7.44s p(90)=5.22s p(95)=5.87s
    iterations..............................................................: 10816  163.603112/s
    vus.....................................................................: 43     min=16         max=998 
    vus_max.................................................................: 1000   min=1000       max=1000

    NETWORK
    data_received...........................................................: 110 MB 1.7 MB/s
    data_sent...............................................................: 3.4 MB 51 kB/s

running (1m06.1s), 0000/1000 VUs, 10816 complete and 0 interrupted iterations
default ✓ [======================================] 0000/1000 VUs  1m0s

```
</details>

<details>
<summary>캐싱 후 (TPS : 475, 응답 시간 평균 49ms)</summary>

```bash

         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: k6-scripts/get-test.js
 web dashboard: http://127.0.0.1:5665
        output: -

     scenarios: (100.00%) 1 scenario, 1000 max VUs, 1m30s max duration (incl. graceful stop):
              * default: Up to 1000 looping VUs for 1m0s over 1 stages (gracefulRampDown: 30s, gracefulStop: 30s)

  █ TOTAL RESULTS 

    checks_total.......................: 57942  950.73257/s
    checks_succeeded...................: 98.10% 56844 out of 57942
    checks_failed......................: 1.89%  1098 out of 57942

    ✓ home: status is 2xx
    ✗ home: response time < 300ms
      ↳  96% — ✓ 27873 / ✗ 1098

    HTTP
    http_req_duration.......................................................: avg=49.69ms min=29µs med=7.34ms max=1.27s p(90)=153.8ms p(95)=250.75ms
      { expected_response:true }............................................: avg=49.69ms min=29µs med=7.34ms max=1.27s p(90)=153.8ms p(95)=250.75ms
    http_req_failed.........................................................: 0.00%  0 out of 28971
    http_reqs...............................................................: 28971  475.366285/s

    EXECUTION
    iteration_duration......................................................: avg=1.05s   min=1s   med=1s     max=2.27s p(90)=1.15s   p(95)=1.25s   
    iterations..............................................................: 28971  475.366285/s
    vus.....................................................................: 117    min=16         max=999 
    vus_max.................................................................: 1000   min=1000       max=1000

    NETWORK
    data_received...........................................................: 293 MB 4.8 MB/s
    data_sent...............................................................: 9.0 MB 147 kB/s

running (1m00.9s), 0000/1000 VUs, 28971 complete and 0 interrupted iterations
default ✓ [======================================] 0000/1000 VUs  1m0s

```
</details>

**→ Redis 캐시 적용으로 TPS 약 3배 향상, 응답 시간 40배 단축 (시나리오 기준)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 친구 목록 조회 시 Redis 캐시를 활용하여 성능을 개선했습니다.

* **버그 수정**
  * 친구 추가/삭제 시 캐시가 자동으로 갱신되어 최신 정보가 반영됩니다.

* **성능 개선**
  * 친구 목록 조회 시 데이터베이스 접근을 최소화하여 응답 속도를 향상시켰습니다.

* **테스트**
  * 부하 테스트 대상 엔드포인트와 가상 사용자 수가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->