### PR TITLE
[refactor] 유저 검색 조회 성능 개선

### DIFF
--- a/k6-scripts/load.js
+++ b/k6-scripts/load.js
@@ -18,7 +18,8 @@ const params = {
 };
 
 export default function () {
-    const res = http.get(`${BASE_URL}/friends`, params);
+    const encodedKeyword = '%EB%A7%99%EA%B5%AC';
+    const res = http.get(`${BASE_URL}/friends/search?keyword=${encodedKeyword}`, params);
     check(res, {
         'status is 2xx': (r) => r.status >= 200 && r.status < 300,
         'response time < 300ms': (r) => r.timings.duration < 300,

--- a/src/main/java/com/example/toyou/repository/FriendRepository.java
+++ b/src/main/java/com/example/toyou/repository/FriendRepository.java
@@ -40,5 +40,10 @@ public interface FriendRepository extends JpaRepository<FriendRequest, Long> {
 
     Boolean existsBySenderAndReceiver(User sender, User receiver);
 
-    Boolean existsBySenderAndReceiverAndAccepted(User sender, User receiver, Boolean accepted);
+    @Query("""
+        SELECT fr FROM FriendRequest fr
+        WHERE (fr.sender = :user AND fr.receiver = :friend)
+           OR (fr.sender = :friend AND fr.receiver = :user)
+    """)
+    Optional<FriendRequest> findBetween(@Param("user") User user, @Param("friend") User friend);
 }

--- a/src/test/http/get-test.http
+++ b/src/test/http/get-test.http
@@ -8,6 +8,11 @@ GET {{baseUrl}}/users/mypage
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
+### 친구(유저) 검색
+GET {{baseUrl}}/friends/search?keyword=맹구
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
 ### 친구 목록 조회
 GET {{baseUrl}}/friends
 Authorization: Bearer {{token}}


### PR DESCRIPTION
## 🔥 Related Issues
- close #42 

## 💻 작업 내용
- [x] 친구 여부 조회 쿼리 단일화
- [x] 실행 계획(EXPLAIN) 분석 👉 인덱스 추가

## ✅ PR Point 
### 시나리오
- 총 유저 160,000명
- 1분 동안 VU(가상 사용자)가 1000명까지 점진적으로 증가
<br>

### 개선 전
<details>
<summary>쿼리 실행 : 100 ~ 200ms</summary>
    
```sql
2025-07-07T01:05:32.393+09:00  INFO 90057 --- [nio-8080-exec-1] c.example.toyou.service.FriendService    : [친구(유저) 검색] userId=1, keyword=user_1000
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        u1_0.id=? 
        and (
            u1_0.is_deleted = 0
        )
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        (
            u1_0.is_deleted = 0
        ) 
        and u1_0.nickname=?
Hibernate: -- 친구 상태에 따라 쿼리 개수 변화(1~4번)
    select
        fr1_0.id 
    from
        friend_request fr1_0 
    where
        fr1_0.sender_id=? 
        and fr1_0.receiver_id=? 
        and fr1_0.accepted=? 
    limit
        ?
Hibernate: 
    select
        fr1_0.id 
    from
        friend_request fr1_0 
    where
        fr1_0.sender_id=? 
        and fr1_0.receiver_id=? 
        and fr1_0.accepted=? 
    limit
        ?
Hibernate: 
    select
        fr1_0.id 
    from
        friend_request fr1_0 
    where
        fr1_0.sender_id=? 
        and fr1_0.receiver_id=? 
        and fr1_0.accepted=? 
    limit
        ?
Hibernate: 
    select
        fr1_0.id 
    from
        friend_request fr1_0 
    where
        fr1_0.sender_id=? 
        and fr1_0.receiver_id=? 
        and fr1_0.accepted=? 
    limit
        ?
2025-07-07T01:05:32.589+09:00  INFO 90057 --- [nio-8080-exec-1] c.example.toyou.service.FriendService    : 친구 상태 : NOT_FRIEND
```
</details>    

<details>
<summary>부하 테스트 : TPS 59.13,  p95 Latency 15.94초</summary>
  
```bash

         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: k6-scripts/load.js
 web dashboard: http://127.0.0.1:5665
        output: -

     scenarios: (100.00%) 1 scenario, 1000 max VUs, 1m30s max duration (incl. graceful stop):
              * default: Up to 1000 looping VUs for 1m0s over 1 stages (gracefulRampDown: 30s, gracefulStop: 30s)

  █ TOTAL RESULTS 

    checks_total.......................: 9070   118.273916/s
    checks_succeeded...................: 50.67% 4596 out of 9070
    checks_failed......................: 49.32% 4474 out of 9070

    ✓ status is 2xx
    ✗ response time < 300ms
      ↳  1% — ✓ 61 / ✗ 4474

    HTTP
    http_req_duration.......................................................: avg=7.5s  min=63.24ms med=7.01s max=17.55s p(90)=15.45s p(95)=15.94s
      { expected_response:true }............................................: avg=7.5s  min=63.24ms med=7.01s max=17.55s p(90)=15.45s p(95)=15.94s
    http_req_failed.........................................................: 0.00%  0 out of 4535
    http_reqs...............................................................: 4535   59.136958/s

    EXECUTION
    iteration_duration......................................................: avg=8.51s min=1.06s   med=8.01s max=18.55s p(90)=16.45s p(95)=16.94s
    iterations..............................................................: 4535   59.136958/s
    vus.....................................................................: 50     min=16        max=998 
    vus_max.................................................................: 1000   min=1000      max=1000

    NETWORK
    data_received...........................................................: 2.4 MB 31 kB/s
    data_sent...............................................................: 1.5 MB 20 kB/s

running (1m16.7s), 0000/1000 VUs, 4535 complete and 0 interrupted iterations
default ✓ [======================================] 0000/1000 VUs  1m0s

```
</details>
<br>

### step 1. 친구 유무 확인 로직 수정
<details>
<summary>쿼리 실행 : 100 ~ 200ms</summary>

```sql
2025-07-07T01:10:02.574+09:00  INFO 91845 --- [nio-8080-exec-1] c.example.toyou.service.FriendService    : [친구(유저) 검색] userId=1, keyword=user_1000
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        u1_0.id=? 
        and (
            u1_0.is_deleted = 0
        )
Hibernate: 
    select
        u1_0.id,
        u1_0.ad_consent,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.is_deleted,
        u1_0.nickname,
        u1_0.oauth_access_token,
        u1_0.oauth_id,
        u1_0.provider,
        u1_0.status,
        u1_0.today_emotion,
        u1_0.updated_at 
    from
        users u1_0 
    where
        (
            u1_0.is_deleted = 0
        ) 
        and u1_0.nickname=?
Hibernate: 
    select
        fr1_0.id,
        fr1_0.accepted,
        fr1_0.checked,
        fr1_0.created_at,
        fr1_0.receiver_id,
        fr1_0.sender_id,
        fr1_0.updated_at 
    from
        friend_request fr1_0 
    where
        (
            fr1_0.sender_id=? 
            and fr1_0.receiver_id=?
        ) 
        or (
            fr1_0.sender_id=? 
            and fr1_0.receiver_id=?
        )
2025-07-07T01:10:02.747+09:00  INFO 91845 --- [nio-8080-exec-1] c.example.toyou.service.FriendService    : 친구 상태 : NOT_FRIEND

```
</details>

<details>
<summary>부하 테스트 : TPS 59.64 → p95 Latency 15.66초</summary>

```bash

         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: k6-scripts/load.js
 web dashboard: http://127.0.0.1:5665
        output: -

     scenarios: (100.00%) 1 scenario, 1000 max VUs, 1m30s max duration (incl. graceful stop):
              * default: Up to 1000 looping VUs for 1m0s over 1 stages (gracefulRampDown: 30s, gracefulStop: 30s)

  █ TOTAL RESULTS 

    checks_total.......................: 9330   119.288726/s
    checks_succeeded...................: 52.95% 4941 out of 9330
    checks_failed......................: 47.04% 4389 out of 9330

    ✓ status is 2xx
    ✗ response time < 300ms
      ↳  5% — ✓ 276 / ✗ 4389

    HTTP
    http_req_duration.......................................................: avg=7.35s min=60.42ms med=6.98s max=17.96s p(90)=14.85s p(95)=15.66s
      { expected_response:true }............................................: avg=7.35s min=60.42ms med=6.98s max=17.96s p(90)=14.85s p(95)=15.66s
    http_req_failed.........................................................: 0.00%  0 out of 4665
    http_reqs...............................................................: 4665   59.644363/s

    EXECUTION
    iteration_duration......................................................: avg=8.35s min=1.06s   med=7.98s max=18.96s p(90)=15.86s p(95)=16.66s
    iterations..............................................................: 4665   59.644363/s
    vus.....................................................................: 19     min=16        max=998 
    vus_max.................................................................: 1000   min=1000      max=1000

    NETWORK
    data_received...........................................................: 2.5 MB 31 kB/s
    data_sent...............................................................: 1.6 MB 20 kB/s

running (1m18.2s), 0000/1000 VUs, 4665 complete and 0 interrupted iterations
default ✓ [======================================] 0000/1000 VUs  1m0s

```
</details>

👉 개선 효과 미비

<br>

### step 2. 인덱스 추가
1️⃣ Explain 분석(닉네임으로 유저 검색)
<img width="634" alt="스크린샷 2025-07-07 오전 1 41 50" src="https://github.com/user-attachments/assets/374fb5f6-ea07-44ce-b618-87eb579a4205" />
- `type: ALL` → 인덱스 없이 테이블 전체를 스캔함 (성능 저하)
- `rows: 159261` → 159,261건 전부 읽고 조건 비교 중 (비효율적 처리)

2️⃣ 인덱스 추가
UNIQUE 제약 조건 설정했으나 DB에 인덱스가 자동 생성되지 않아 수동 생성
```sql
ALTER TABLE users ADD CONSTRAINT uk_user_nickname UNIQUE (nickname);
```

3️⃣ 인덱스 적용 결과
<img width="628" alt="스크린샷 2025-07-07 오전 10 48 26" src="https://github.com/user-attachments/assets/bfd0aa12-3087-4623-a6f6-72019902658f" />
- `type: const` → 유니크 인덱스를 이용한 단일 값 상수 조건 탐색
- `rows: 1` → 조건에 맞는 row 1건만 읽음

쿼리 실행 시간 : 약 30ms

<details>
<summary>부하 테스트 : TPS 488.86, p95 Latency 70.43ms</summary>

```bash

         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: k6-scripts/load.js
 web dashboard: http://127.0.0.1:5665
        output: -

     scenarios: (100.00%) 1 scenario, 1000 max VUs, 1m30s max duration (incl. graceful stop):
              * default: Up to 1000 looping VUs for 1m0s over 1 stages (gracefulRampDown: 30s, gracefulStop: 30s)

  █ TOTAL RESULTS 

    checks_total.......................: 59666  977.724927/s
    checks_succeeded...................: 49.61% 29606 out of 59666
    checks_failed......................: 50.38% 30060 out of 59666

    ✗ status is 2xx
      ↳  0% — ✓ 0 / ✗ 29833
    ✗ response time < 300ms
      ↳  99% — ✓ 29606 / ✗ 227

    HTTP
    http_req_duration......................: avg=20.35ms min=2.23ms med=8.56ms max=783.51ms p(90)=38.96ms p(95)=70.43ms
    http_req_failed........................: 100.00% 29833 out of 29833
    http_reqs..............................: 29833   488.862463/s

    EXECUTION
    iteration_duration.....................: avg=1.02s   min=1s     med=1s     max=1.78s    p(90)=1.04s   p(95)=1.07s  
    iterations.............................: 29833   488.862463/s
    vus....................................: 107     min=16             max=998 
    vus_max................................: 1000    min=1000           max=1000

    NETWORK
    data_received..........................: 15 MB   237 kB/s
    data_sent..............................: 10 MB   168 kB/s

running (1m01.0s), 0000/1000 VUs, 29833 complete and 0 interrupted iterations

```
</details>
<br>

> 인덱스 적용으로 `type: ALL → const`, `rows: 159,261 → 1`로 최적화됨.
> 쿼리 실행 시간 100~200ms → 약 30ms로 단축.
> 시나리오 기준 TPS 59 → 488, p95 Latency 15s → 70ms로 개선.
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `/friends/search` 엔드포인트에 대한 검색 기능 테스트 케이스가 추가되었습니다.

* **리팩터링**
  * 친구 상태 판별 로직이 단일 쿼리와 간결한 매핑 함수로 통합되어 효율성이 향상되었습니다.

* **기타**
  * 부가적인 내부 코드 개선이 이루어졌으나, 외부 API에는 변경 사항이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->